### PR TITLE
fix: update thumbnails of live streams if old one is more than 5 minutes old

### DIFF
--- a/TwitchScript.js
+++ b/TwitchScript.js
@@ -587,12 +587,14 @@ function getLiveVideo(url, video_details = true) {
 
     const hls_source = new HLSSource({ name: 'live', duration: 0, url: hls_url })
 
+	const cacheBust = Math.floor(Date.now() / 300000); // refresh every 5 min
+
     const pv = new PlatformVideo({
         id: new PlatformID(PLATFORM, sm.id, config.id),
         name: sm.lastBroadcast.title,
         thumbnails: new Thumbnails([
-            new Thumbnail(`https://static-cdn.jtvnw.net/previews-ttv/live_user_${login}-1280x720.jpg`, 720),
-            new Thumbnail(`https://static-cdn.jtvnw.net/previews-ttv/live_user_${login}-854x480.jpg`, 480),
+            new Thumbnail(`https://static-cdn.jtvnw.net/previews-ttv/live_user_${login}-1280x720.jpg?t=${cacheBust}`, 720),
+            new Thumbnail(`https://static-cdn.jtvnw.net/previews-ttv/live_user_${login}-854x480.jpg?t=${cacheBust}`, 480),
         ]),
         author: new PlatformAuthorLink(new PlatformID(PLATFORM, sm.channel.id, config.id, PLATFORM_CLAIMTYPE), login, url, sm.profileImageURL),
         uploadDate: parseInt(new Date(ul.stream.createdAt).getTime() / 1000),


### PR DESCRIPTION
Thumbnails of live streams are cached for a very long time. Meaning that when a live stream shows on your feed it has the thumbnail from when it first appeared on your feed. Days, weeks or even months ago, which doesn't reflect the current live stream content.

This PR just adds an extra parameter to the URL of the thumbnail so that the URL changes and it can't be found on the cache after 5 minutes.